### PR TITLE
simplify email template to have fewer manual entry variables

### DIFF
--- a/sunshine/templates/email-template.html
+++ b/sunshine/templates/email-template.html
@@ -5,7 +5,7 @@
 <h3>Sample Email Template</h3>
 
 <p>[Date of Request]</p>
-<p>Dear [Contact],</p>
+<p>To Whom It May Concern,</p>
 
 <p>
 Under the <strong>California Public Records Act § 6250 et seq.</strong>, and

--- a/sunshine/views.py
+++ b/sunshine/views.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import os
+import time
 from flask import render_template, jsonify, request, json, abort
 
 from sunshine import app
@@ -68,8 +69,7 @@ def get_contacts():
         return json.load(f)['contacts']['San Francisco']
 
 email_body = """
-[Date of Request]%0D%0A
-Dear [Contact],%0D%0A
+To Whom It May Concern,%0D%0A
 %0D%0A
 %0D%0A
 Under the California Public Records Act 6250 et seq., and 


### PR DESCRIPTION
This pull request removes the date and department contact name placeholders from the email template, replacing the latter with an all-purpose "To Whom It May Concern," a la MuckRock.

This request also imports the time library in views.py, in anticipation of automatically adding a well-formatted date string to the top of the email template.